### PR TITLE
Adds the Giovanni and Malkavian Clan as part of possible Clans

### DIFF
--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -45,6 +45,7 @@
 #define CLAN_NOSFERATU "Nosferatu Clan" // Can't use Masquerade
 #define CLAN_TREMERE "Tremere Clan" // Weaker to some Holy tools, and burns while in the Chapel (Like the Vampire race)
 #define CLAN_VENTRUE "Ventrue Clan" // Cant drink blood out of mindless mobs
+#define CLAN_GIOVANNI "Giovanni Clan" // Feeding on living beings is difficult (Violent message and more damage on interrupt, target screams on silent grab)
 
 /*
  *	Deputy Defines

--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -46,6 +46,7 @@
 #define CLAN_TREMERE "Tremere Clan" // Weaker to some Holy tools, and burns while in the Chapel (Like the Vampire race)
 #define CLAN_VENTRUE "Ventrue Clan" // Cant drink blood out of mindless mobs
 #define CLAN_GIOVANNI "Giovanni Clan" // Feeding on living beings is difficult (Violent message and more damage on interrupt, target screams on silent grab)
+#define CLAN_MALKAVIAN "Malkavian Clan" // Constant hallucinations. Maybe obtain sleepless dreamer/bluespace prophet if clans ever get bonuses?
 
 /*
  *	Deputy Defines

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -352,6 +352,7 @@
 			CLAN_NOSFERATU,
 			CLAN_TREMERE,
 			CLAN_VENTRUE,
+			CLAN_GIOVANNI,
 			)
 		AssignRandomBane(my_clan)
 	to_chat(owner.current, "<span class='notice'>You are now a rank [bloodsucker_level] Bloodsucker. Your strength, health, feed rate, regen rate, and maximum blood capacity have all increased!</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -353,6 +353,7 @@
 			CLAN_TREMERE,
 			CLAN_VENTRUE,
 			CLAN_GIOVANNI,
+			CLAN_MALKAVIAN,
 			)
 		AssignRandomBane(my_clan)
 	to_chat(owner.current, "<span class='notice'>You are now a rank [bloodsucker_level] Bloodsucker. Your strength, health, feed rate, regen rate, and maximum blood capacity have all increased!</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -90,4 +90,9 @@
 				* As part of the Ventrue Clan, you are extremely snobby with your meals, and refuse to drink blood from people without a Mind.</span>")
 		if(CLAN_GIOVANNI)
 			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Giovanni Clan!<br> \
-				* As part of the Giovanni Clan, your bites are unforgiving and loud, causing screams even in an attempt to be silenced and violently spraying blood if interrupted.</span>")
+				* As part of the Giovanni Clan, your bites are unforgiving and loud, causing screams even in an attempt to be silent and violently spraying blood if interrupted.</span>")
+		if(CLAN_MALKAVIAN)
+			var/mob/living/carbon/human/bloodsucker = owner.current
+			bloodsucker.gain_trauma(/datum/brain_trauma/mild/hallucinations, TRAUMA_RESILIENCE_ABSOLUTE)
+			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Malkavian Clan!<br> \
+				* As part of the Malkavian Clan, you see the world in a different way, suffering hallucinations.</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -68,23 +68,26 @@
  */
 
 /datum/antagonist/bloodsucker/proc/AssignRandomBane(my_clan)
-	if(my_clan)
-		if(my_clan == CLAN_BRUJAH)
+	if(!my_clan)
+		to_chat(owner, "<span class='warning'>You have not been assigned to a Clan.</span>")
+		return
+	switch(my_clan)
+		if(CLAN_BRUJAH)
 			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Brujah Clan!<br> \
 				* As part of the Bujah Clan, you are more prone to falling into Frenzy, don't let your blood drop too low!</span>")
-		if(my_clan == CLAN_NOSFERATU)
+		if(CLAN_NOSFERATU)
 			for(var/datum/action/bloodsucker/power in powers)
 				if(istype(power, /datum/action/bloodsucker/masquerade))
 					powers -= power
 					power.Remove(owner.current)
 			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Nosferatu Clan!<br> \
 				* As part of the Nosferatu Clan, you are less interested in disguising yourself within the crew, as such you do not know how to use the Masquerade ability.</span>")
-		if(my_clan == CLAN_TREMERE)
+		if(CLAN_TREMERE)
 			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Tremere Clan!<br> \
 				* As part of the Tremere Clan, you are weak to Anti-magic, and will catch fire if you enter the Chapel!</span>")
-		if(my_clan == CLAN_VENTRUE)
+		if(CLAN_VENTRUE)
 			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Ventrue Clan!<br> \
 				* As part of the Ventrue Clan, you are extremely snobby with your meals, and refuse to drink blood from people without a Mind.</span>")
-	else
-		to_chat(owner, "<span class='warning'>You have not been assigned to a Clan.</span>")
-
+		if(CLAN_GIOVANNI)
+			to_chat(owner, "<span class='announce'>You have Ranked up enough to learn: You are part of the Giovanni Clan!<br> \
+				* As part of the Giovanni Clan, your bites are unforgiving and loud, causing screams even in an attempt to be silenced and violently spraying blood if interrupted.</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/feed.dm
@@ -143,6 +143,7 @@
 	var/mob/living/target = feed_target // Stored during CheckCanUse(). Can be a grabbed OR adjecent character.
 	var/mob/living/user = owner
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)
+	var/giovanni_member = bloodsuckerdatum.my_clan == CLAN_GIOVANNI
 	// Am I SECRET or LOUD? It stays this way the whole time! I must END IT to try it the other way.
 	var/amSilent = (!target_grappled || owner.grab_state <= GRAB_PASSIVE) //  && iscarbon(target) // Non-carbons (animals) not passive. They go straight into aggressive.
 	// Initial Wait
@@ -176,7 +177,7 @@
 		//else
 		var/deadmessage = target.stat == DEAD ? "" : " <i>[target.p_they(TRUE)] looks dazed, and will not remember this.</i>"
 		user.visible_message("<span class='notice'>[user] puts [target]'s wrist up to [user.p_their()] mouth.</span>", \
-						 	 "<span class='notice'>You secretly slip your fangs into [target]'s wrist.[deadmessage]</span>", \
+						 	 "<span class='notice'>You slip your fangs into [target]'s wrist.[deadmessage]</span>", \
 						 	 vision_distance = notice_range, ignored_mobs = target) // Only people who AREN'T the target will notice this action.
 		// Warn Feeder about Witnesses...
 		var/was_unnoticed = TRUE
@@ -184,7 +185,12 @@
 			if(M.client && !M.has_unlimited_silicon_privilege && !M.eye_blind && !M.mind.has_antag_datum(/datum/antagonist/bloodsucker))
 				was_unnoticed = FALSE
 				break
-		if(was_unnoticed)
+		if(giovanni_member)
+			to_chat(target, "<span class='userdanger'>You feel a sharp stinging pain on your wrist!</span>")
+			target.take_overall_damage(5)
+			target.add_confusion(20)
+			INVOKE_ASYNC(target, /mob.proc/emote, "scream")
+		if(was_unnoticed && !giovanni_member)
 			to_chat(user, "<span class='notice'>You think no one saw you...</span>")
 		else
 			to_chat(user, "<span class='warning'>Someone may have noticed...</span>")
@@ -215,12 +221,14 @@
 			if(!active || !ContinueActive(user, target))
 				break
 
-			if(amSilent)
+			if(amSilent && !giovanni_member) // If you're of the Giovanni clan, feeds CAN'T be silent.
 				to_chat(user, "<span class='warning'>Your feeding has been interrupted...but [target.p_they()] didn't seem to notice you.<span>")
 			else
+				var/user_message = giovanni_member ? "Your teeth are ripped away from [target] violently!" : "Your teeth are ripped from [target]'s throat."
+				var/bystander_message = giovanni_member ? "[user] is ripped violently from [target]!" : "[user] is ripped from [target]'s throat."
 				to_chat(user, "<span class='warning'>Your feeding has been interrupted!</span>")
-				user.visible_message("<span class='danger'>[user] is ripped from [target]'s throat. [target.p_their(TRUE)] blood sprays everywhere!</span>", \
-						 			 "<span class='userdanger'>Your teeth are ripped from [target]'s throat. [target.p_their(TRUE)] blood sprays everywhere!</span>")
+				user.visible_message("<span class='danger'>[bystander_message] [target.p_their(TRUE)] blood sprays everywhere!</span>", \
+						 			 "<span class='userdanger'>[user_message] [target.p_their(TRUE)] blood sprays everywhere!</span>")
 				REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, BLOODSUCKER_TRAIT)
 				// Deal Damage to Target (should have been more careful!)
 				if(iscarbon(target))
@@ -235,7 +243,11 @@
 				target.add_splatter_floor(get_turf(target))
 				user.add_mob_blood(target) // Put target's blood on us. The donor goes in the ( )
 				target.add_mob_blood(target)
-				target.take_overall_damage(10,0)
+				// Giovanni Clan and alive target? That's a harsh bite.
+				if(giovanni_member && target.stat < DEAD)
+					target.take_overall_damage(20)
+				else
+					target.take_overall_damage(10)
 				INVOKE_ASYNC(target, /mob.proc/emote, "scream")
 
 			return


### PR DESCRIPTION
## About The Pull Request

Adds the Giovanni clan, known for their power in necromancy (clans aren't meant to have bonuses right now soooo) and for their harsh bites.
Their drawback is feeding being unable to be silent, an attempt at silent feeding results in the victim screaming alongside a visible text to them, however, the feed is not broken until the victim moves away.
Also makes breaking feed for Giovanni always have the aggressive_grab feed break outcome (blood spray, visible messages, damage)
Improves RandomBane code to use a switch statement

Also adds the Malkavian clan, who see the "truth" and generally observe the world differently. This is reflected in-game with permanent hallucinations as their drawback.