### PR TITLE
[UNTESTED] Bea's Bloodsucker Suggestions

### DIFF
--- a/code/___fulp_defines/fulp_defines.dm
+++ b/code/___fulp_defines/fulp_defines.dm
@@ -38,6 +38,12 @@
 #define TRAIT_COLDBLOODED "coldblooded"
 /// Used for Bloodsucker's LifeTick() signal
 #define COMSIG_LIVING_BIOLOGICAL_LIFE "biological_life"
+/// Used for determining the rate at which a bloodsucker regens
+#define BS_BLOOD_VOLUME_MAX_REGEN 700
+/// Frenzy Thresholds
+#define FRENZY_THRESHOLD_NORMAL 25
+#define FRENZY_THRESHOLD_HIGHER 200
+#define FRENZY_THRESHOLD_EXIT 250
 /// Antagonist checks
 #define IS_BLOODSUCKER(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/bloodsucker))
 #define IS_VASSAL(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/vassal))

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/bloodsucker_datum.dm
@@ -34,6 +34,7 @@
 	var/list/datum/antagonist/vassal/vassals = list()
 	///Who made me? For both Vassals AND Bloodsuckers (though Master Vamps won't have one)
 	var/datum/mind/creator
+	var/frenzy_threshold = FRENZY_THRESHOLD_NORMAL
 
 	///Powers
 	var/list/datum/action/powers = list()
@@ -118,8 +119,6 @@
 	clan.check_cancel_sunlight()
 	ClearAllPowersAndStats()
 	update_bloodsucker_icons_removed(owner.current)
-	if(!LAZYLEN(owner.antag_datums))
-		owner.current.remove_from_current_living_antags()
 	return ..()
 
 /datum/antagonist/bloodsucker/greet()
@@ -357,6 +356,13 @@
 /datum/antagonist/bloodsucker/proc/LevelUpPowers()
 	for(var/datum/action/bloodsucker/power in powers)
 		power.level_current++
+
+///Disables all powers, accounting for torpor
+/datum/antagonist/bloodsucker/proc/DisableAllPowers()
+	for(var/datum/action/bloodsucker/power in powers)
+		if(!HAS_TRAIT(owner.current, TRAIT_NODEATH) || !power.can_use_in_torpor) // If you AREN'T in torpor or you CANT use it in torpor
+			if(power.active)
+				power.DeactivatePower()
 
 /datum/antagonist/bloodsucker/proc/SpendRank()
 	set waitfor = FALSE

--- a/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/antagonists/monsterhunter_datum.dm
@@ -81,7 +81,7 @@
 	/// Remove Martial Arts
 	if(my_kungfu)
 		my_kungfu.remove(owner.current)
-	to_chat(owner.current, "<span class='userdanger'>Your hunt has ended: You enter retirement, and are no longer a Monster Hunter.</span>")
+	to_chat(owner.current, "<span class='userdanger'>Your hunt has ended: You enter retirement once again, and are no longer a Monster Hunter.</span>")
 	return ..()
 
 /// Mind version

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_coffin.dm
@@ -1,7 +1,7 @@
-/datum/antagonist/bloodsucker/proc/ClaimCoffin(obj/structure/closet/crate/claiming)
+/datum/antagonist/bloodsucker/proc/ClaimCoffin(obj/structure/closet/crate/claimed)
 	// ALREADY CLAIMED
-	if(claiming.claimed_by)
-		if(claiming.claimed_by == owner.current)
+	if(claimed.resident)
+		if(claimed.resident == owner.current)
 			to_chat(owner, "This is your [src].")
 		else
 			to_chat(owner, "This [src] has already been claimed by another.")
@@ -10,16 +10,16 @@
 	owner.teach_crafting_recipe(/datum/crafting_recipe/candelabrum)
 	owner.teach_crafting_recipe(/datum/crafting_recipe/meatcoffin)
 	// This is my Lair
-	coffin = claiming
-	lair = get_area(claiming)
-	to_chat(owner, "<span class='userdanger'>You have claimed the [claiming] as your place of immortal rest! Your lair is now [lair].</span>")
+	coffin = claimed
+	lair = get_area(claimed)
+	to_chat(owner, "<span class='userdanger'>You have claimed the [claimed] as your place of immortal rest! Your lair is now [lair].</span>")
 	to_chat(owner, "<span class='danger'>You have learned new construction recipes to improve your lair.</span>")
 	to_chat(owner, "<span class='announce'>Bloodsucker Tip: Find new lair recipes in the Misc tab of the <i>Crafting Menu</i>, including the <i>Persuasion Rack</i> for converting crew into Vassals.</span><br><br>")
 	return TRUE
 
 /// From crate.dm
 /obj/structure/closet/crate
-	var/mob/living/claimed_by /// This lets bloodsuckers claim any "closet" as a Coffin.
+	var/mob/living/resident /// This lets bloodsuckers claim any "closet" as a Coffin.
 	var/pryLidTimer = 250
 	breakout_time = 200
 
@@ -75,7 +75,7 @@
 	if(bloodsuckerdatum)
 		// Successfully claimed?
 		if(bloodsuckerdatum.ClaimCoffin(src))
-			claimed_by = claimant
+			resident = claimant
 			anchored = 1
 			START_PROCESSING(SSprocessing, src)
 
@@ -139,20 +139,20 @@
 					area_turfs -= T*/
 
 /obj/structure/closet/crate/proc/UnclaimCoffin()
-	if(claimed_by)
+	if(resident)
 		// Unclaiming
-		if(claimed_by.mind)
-			var/datum/antagonist/bloodsucker/bloodsuckerdatum = claimed_by.mind.has_antag_datum(/datum/antagonist/bloodsucker)
+		if(resident.mind)
+			var/datum/antagonist/bloodsucker/bloodsuckerdatum = resident.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 			if(bloodsuckerdatum && bloodsuckerdatum.coffin == src)
 				bloodsuckerdatum.coffin = null
 				bloodsuckerdatum.lair = null
-			to_chat(claimed_by, "<span class='cult'><span class='italics'>You sense that the link with your coffin, your sacred place of rest, has been broken! You will need to seek another.</span></span>")
-		claimed_by = null // Remove claimed_by. Because this object isnt removed from the game immediately (GC?) we need to give them a way to see they don't have a home anymore.
+			to_chat(resident, "<span class='cult'><span class='italics'>You sense that the link with your coffin, your sacred place of rest, has been broken! You will need to seek another.</span></span>")
+		resident = null // Remove resident. Because this object isnt removed from the game immediately (GC?) we need to give them a way to see they don't have a home anymore.
 
 /// You cannot lock in/out a coffin's owner. SORRY.
 /obj/structure/closet/crate/coffin/can_open(mob/living/user)
 	if(locked)
-		if(user == claimed_by)
+		if(user == resident)
 			if(welded)
 				welded = FALSE
 				update_icon()
@@ -171,7 +171,7 @@
 		var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 		if(bloodsuckerdatum)
 			LockMe(user)
-			if(!bloodsuckerdatum.coffin && !claimed_by)
+			if(!bloodsuckerdatum.coffin && !resident)
 				switch(tgui_alert(user,"Do you wish to claim this as your coffin? [get_area(src)] will be your lair.","Claim Lair", list("Yes", "No")))
 					if("Yes")
 						ClaimCoffin(user)
@@ -184,7 +184,7 @@
 
 /// You cannot weld or deconstruct an owned coffin. Only the owner can destroy their own coffin.
 /obj/structure/closet/crate/coffin/attackby(obj/item/W, mob/user, params)
-	if(claimed_by != null && user != claimed_by)
+	if(resident != null && user != resident)
 		if(opened)
 			if(istype(W, cutting_tool))
 				to_chat(user, "<span class='notice'>This is a much more complex mechanical structure than you thought. You don't know where to begin cutting [src].</span>")
@@ -211,14 +211,14 @@
 		LockMe(user, !locked)
 
 /obj/structure/closet/crate/proc/LockMe(mob/user, inLocked = TRUE)
-	if(user == claimed_by)
+	if(user == resident)
 		if(!broken)
 			locked = inLocked
 			to_chat(user, "<span class='notice'>You flip a secret latch and [locked?"":"un"]lock yourself inside [src].</span>")
 		else
-			to_chat(claimed_by, "<span class='notice'>The secret latch to lock [src] from the inside is broken. You set it back into place...</span>")
-			if(do_mob(claimed_by, src, 5 SECONDS))
+			to_chat(resident, "<span class='notice'>The secret latch to lock [src] from the inside is broken. You set it back into place...</span>")
+			if(do_mob(resident, src, 5 SECONDS))
 				if(broken) // Spam Safety
-					to_chat(claimed_by, "<span class='notice'>You fix the mechanism and lock it.</span>")
+					to_chat(resident, "<span class='notice'>You fix the mechanism and lock it.</span>")
 					broken = FALSE
 					locked = TRUE

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_flaws.dm
@@ -89,7 +89,7 @@
 		Tremere - Burn in the Chapel, Vassal Mutilation.<br> \
 		Ventrue - Cant drink from mindless mobs, can't level up, raise a vassal instead.<br></span>")
 	if(!isbeefman(bloodsucker))
-		to_chat(owner, "<span class='announce'>Malakavian - Complete insanity.<br></span>")
+		to_chat(owner, "<span class='announce'>Malkavian - Complete insanity.<br></span>")
 	to_chat(owner, "<span class='announce'>* Read more about Clans here: https://wiki.fulp.gg/en/Bloodsucker.<br></span>")
 
 	var/answer = tgui_input_list(owner.current, "You have Ranked up far enough to remember your clan. Which clan are you part of?", "Our mind feels luxurious...", options)
@@ -102,6 +102,7 @@
 			/// Makes their max punch, and by extension Brawn, stronger - Stolen from SpendRank()
 			var/datum/species/S = bloodsucker.dna.species
 			S.punchdamagehigh += 1.5
+			frenzy_threshold = FRENZY_THRESHOLD_HIGHER
 			return
 		if(CLAN_NOSFERATU)
 			my_clan = CLAN_NOSFERATU

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -106,7 +106,6 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// NOTE: Mult of 0 is just a TEST to see if we are injured and need to go into Torpor!
 /// It is called from your coffin on close (by you only)
 /datum/antagonist/bloodsucker/proc/HandleHealing(mult = 1)
 	var/actual_regen = bloodsucker_regen_rate + additional_regen
@@ -124,10 +123,11 @@
 		var/bruteheal = min(C.getBruteLoss_nonProsthetic(), actual_regen) // BRUTE: Always Heal
 		var/fireheal = 0 // BURN: Heal in Coffin while Fakedeath, or when damage above maxhealth (you can never fully heal fire)
 		/// Checks if you're in a coffin here, additionally checks for Torpor right below it.
-		var/amInCoffinWhileTorpor = istype(C.loc, /obj/structure/closet/crate/coffin)
-		if(amInCoffinWhileTorpor && HAS_TRAIT(C, TRAIT_NODEATH))
+		var/amInCoffin = istype(C.loc, /obj/structure/closet/crate/coffin)
+		if(amInCoffin && HAS_TRAIT(C, TRAIT_NODEATH))
 			fireheal = min(C.getFireLoss_nonProsthetic(), actual_regen)
 			mult *= 5 // Increase multiplier if we're sleeping in a coffin.
+			costMult /= 2 // Decrease cost if we're sleeping in a coffin.
 			C.extinguish_mob()
 			C.remove_all_embedded_objects() // Remove Embedded!
 			if(check_limbs(costMult))
@@ -136,22 +136,22 @@
 		else if(HAS_TRAIT(C, TRAIT_NODEATH))
 			mult *= 3
 		/// Heal if Damaged
-		if(bruteheal + fireheal > 0) // Just a check? Don't heal/spend, and return.
+		if((bruteheal + fireheal > 0) && mult != 0) // Just a check? Don't heal/spend, and return.
 			// We have damage. Let's heal (one time)
 			C.adjustBruteLoss(-bruteheal * mult, forced=TRUE) // Heal BRUTE / BURN in random portions throughout the body.
 			C.adjustFireLoss(-fireheal * mult, forced=TRUE)
-			AddBloodVolume((bruteheal * -0.5 + fireheal * -1) / mult * costMult) // Costs blood to heal
+			AddBloodVolume(((bruteheal * -0.5) + (fireheal * -1)) * costMult * mult) // Costs blood to heal
 			return TRUE
 
-/datum/antagonist/bloodsucker/proc/check_limbs(costMult)
-	var/limb_regen_cost = 50 * costMult
+/datum/antagonist/bloodsucker/proc/check_limbs(costMult = 1)
+	var/limb_regen_cost = 50 * -costMult
 	var/mob/living/carbon/C = owner.current
 	var/list/missing = C.get_missing_limbs()
 	if(missing.len && C.blood_volume < limb_regen_cost + 5)
 		return FALSE
 	for(var/targetLimbZone in missing) // 1) Find ONE Limb and regenerate it.
 		C.regenerate_limb(targetLimbZone, FALSE) // regenerate_limbs() <--- If you want to EXCLUDE certain parts, do it like this ----> regenerate_limbs(0, list("head"))
-		AddBloodVolume(50)
+		AddBloodVolume(limb_regen_cost)
 		var/obj/item/bodypart/L = C.get_bodypart(targetLimbZone) // 2) Limb returns Damaged
 		L.brute_dam = 60
 		to_chat(C, "<span class='notice'>Your flesh knits as it regrows your [L]!</span>")
@@ -188,7 +188,7 @@
 		H.Stop()
 	var/obj/item/organ/eyes/E = bloodsuckeruser.getorganslot(ORGAN_SLOT_EYES)
 	if(E)
-		E.flash_protect -= 1
+		E.flash_protect = max(initial(E.flash_protect) - 1, FLASH_PROTECTION_SENSITIVE)
 		E.sight_flags = SEE_MOBS
 		E.see_in_dark = 8
 		E.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
@@ -279,19 +279,17 @@
 	// BLOOD_VOLUME_GOOD: [336] - Pale
 //	handled in bloodsucker_integration.dm
 	// BLOOD_VOLUME_BAD: [224] - Jitter
-	if(owner.current.blood_volume < BLOOD_VOLUME_BAD && !prob(0.5 && HAS_TRAIT(owner, TRAIT_NODEATH)) && !poweron_masquerade)
+	if(owner.current.blood_volume < BLOOD_VOLUME_BAD && prob(0.5) && !HAS_TRAIT(owner.current, TRAIT_NODEATH) && !poweron_masquerade)
 		owner.current.Jitter(3)
 	/// Blood Volume: 250 - Exit Frenzy (If in one) This is really high because we want this to be enough to kill the poor soul they feed off of.
-	if(owner.current.blood_volume >= 250 && Frenzied)
+	if(owner.current.blood_volume >= FRENZY_THRESHOLD_EXIT && Frenzied)
 		Frenzy_End()
 	// BLOOD_VOLUME_SURVIVE: [122]  Blur Vision
 	if(owner.current.blood_volume < BLOOD_VOLUME_SURVIVE)
 		owner.current.blur_eyes(8 - 8 * (owner.current.blood_volume / BLOOD_VOLUME_BAD))
 
 	/// Frenzy & Regeneration - The more blood, the better the Regeneration, get too low blood, and you enter Frenzy.
-	if(owner.current.blood_volume < 25 && !Frenzied)
-		Frenzy_Start()
-	else if(owner.current.blood_volume < 200 && my_clan == CLAN_BRUJAH && !Frenzied)
+	if(owner.current.blood_volume < frenzy_threshold && !Frenzied)
 		Frenzy_Start()
 	else if(owner.current.blood_volume < BLOOD_VOLUME_BAD)
 		additional_regen = 0.1
@@ -299,8 +297,10 @@
 		additional_regen = 0.2
 	else if(owner.current.blood_volume < BLOOD_VOLUME_NORMAL)
 		additional_regen = 0.3
-	else if(owner.current.blood_volume < 700)
+	else if(owner.current.blood_volume < BS_BLOOD_VOLUME_MAX_REGEN)
 		additional_regen = 0.4
+	else
+		additional_regen = 0.5
 
 /// Frenzy's End is in HandleStarving.
 /datum/antagonist/bloodsucker/proc/Frenzy_Start()
@@ -316,9 +316,7 @@
 		ADD_TRAIT(owner.current, TRAIT_MUTE, BLOODSUCKER_TRAIT)
 		ADD_TRAIT(owner.current, TRAIT_DEAF, BLOODSUCKER_TRAIT)
 		// Disable ALL Powers
-		for(var/datum/action/bloodsucker/power in powers)
-			if(power.active)
-				power.DeactivatePower()
+		DisableAllPowers()
 		if(HAS_TRAIT(owner.current, TRAIT_ADVANCEDTOOLUSER))
 			REMOVE_TRAIT(owner.current, TRAIT_ADVANCEDTOOLUSER, SPECIES_TRAIT)
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dna_vault_speedup)
@@ -377,12 +375,11 @@
 			/// Otherwise, check if it's Sol, to enter Torpor.
 			if(clan.bloodsucker_sunlight.amDay)
 				Check_Begin_Torpor(TRUE)
-		/// You are in Torpor, and in a Coffin. Check if it's not Daytime & you have less than 10 Brute/Burn combined to end Torpor.
-		else if(!clan.bloodsucker_sunlight.amDay && total_damage <= 10)
+		/// You are in Torpor, and in a Coffin. Check if you are supposed to end torpor
+		else
 			Check_End_Torpor()
-	/// You're not in a Coffin, but are in Torpor. Check if it's not Daytime, & you have less than 10 Brute (NOT Burn) to end Torpor.
-	else if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10 && HAS_TRAIT(owner.current, TRAIT_NODEATH))
-		Check_End_Torpor()
+	/// You're not in a Coffin, but are in Torpor. Check if you are supposed to end torpor
+	Check_End_Torpor()
 
 /datum/antagonist/bloodsucker/proc/Check_Begin_Torpor(SkipChecks = FALSE)
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!
@@ -397,11 +394,11 @@
 	if(!clan.bloodsucker_sunlight.amDay && total_damage >= 10 && !HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		Torpor_Begin()
 
-/datum/antagonist/bloodsucker/proc/Check_End_Torpor()
-	/// You're not in Sol? (Slept in a Locker for example), then you don't need to leave it.
+/datum/antagonist/bloodsucker/proc/Check_End_Torpor(SkipChecks = FALSE)
+	/// You're not in Torpor? (Slept in a Locker for example), then you don't need to leave it.
 	if(!HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		return
-	/// Sol ended OR Have 0 Brute damage, and you're not in a Coffin? End Torpor.
+	/// Not in a Coffin? End Torpor.
 	if(!istype(owner.current.loc, /obj/structure/closet/crate/coffin))
 		Torpor_End()
 	else
@@ -424,9 +421,7 @@
 	ADD_TRAIT(owner.current, TRAIT_RESISTLOWPRESSURE, BLOODSUCKER_TRAIT)
 	owner.current.Jitter(0)
 	/// Disable ALL Powers
-	for(var/datum/action/bloodsucker/power in powers)
-		if(power.active && !power.can_use_in_torpor)
-			power.DeactivatePower()
+	DisableAllPowers()
 
 /datum/antagonist/bloodsucker/proc/Torpor_End()
 	to_chat(owner.current, "<span class='warning'>You have recovered from Torpor.</span>")

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -121,7 +121,8 @@
 		var/amInCoffin = istype(C.loc, /obj/structure/closet/crate/coffin)
 		if(amInCoffin && HAS_TRAIT(C, TRAIT_NODEATH))
 			if(poweron_masquerade)
-				to_chat(C, "<span class='warning'>You will not heal while your Masquerade ability is active.</span>")
+				to_chat(C, "<span class='warning'>You return to your true form once again to mend your wounds.</span>")
+				DeactivateAllPowers()
 			fireheal = min(C.getFireLoss_nonProsthetic(), actual_regen)
 			mult *= 5 // Increase multiplier if we're sleeping in a coffin.
 			costMult /= 2 // Decrease cost if we're sleeping in a coffin.

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_life.dm
@@ -121,8 +121,7 @@
 		var/amInCoffin = istype(C.loc, /obj/structure/closet/crate/coffin)
 		if(amInCoffin && HAS_TRAIT(C, TRAIT_NODEATH))
 			if(poweron_masquerade)
-				to_chat(C, "<span class='warning'>You return to your true form once again to mend your wounds.</span>")
-				DeactivateAllPowers()
+				to_chat(C, "<span class='warning'>You will not heal while your Masquerade ability is active.</span>")
 			fireheal = min(C.getFireLoss_nonProsthetic(), actual_regen)
 			mult *= 5 // Increase multiplier if we're sleeping in a coffin.
 			costMult /= 2 // Decrease cost if we're sleeping in a coffin.
@@ -306,7 +305,7 @@
 		to_chat(owner.current, "<span class='announce'>You enter a Frenzy!<br> \
 		* While in Frenzy, you gain the ability to instantly aggressively grab people, move faster and have no blood cost on abilities.<br> \
 		* In exchange, you will slowly gain Burn damage, be careful of how you handle it!<br> \
-		* To leave Frenzy, simply drink enough Blood (250) to exit.</span><br>")
+		* To leave Frenzy, simply drink enough Blood ([FRENZY_THRESHOLD_EXIT]) to exit.</span><br>")
 	else
 		to_chat(owner.current, "<span class='userdanger'><FONT size = 3>Blood! You need Blood, now! You enter a total Frenzy!</span>")
 		to_chat(owner.current, "<span class='announce'>* Bloodsucker Tip: While in Frenzy, you instantly Aggresively grab, cannot speak, hear, get stunned, or use any powers outside of Feed and Trespass (If you have it).</span><br>")
@@ -373,11 +372,12 @@
 			/// Otherwise, check if it's Sol, to enter Torpor.
 			if(clan.bloodsucker_sunlight.amDay)
 				Check_Begin_Torpor(TRUE)
-		/// You are in Torpor, and in a Coffin. Check if you are supposed to end torpor
-		else
+		/// You are in Torpor, and in a Coffin. Check if it's not Daytime & you have less than 10 Brute/Burn combined to end Torpor. WILLARD TODO: Condense all the checks into Check_End_Torpor(), then just call that instead of checking twice.6
+		else if(!clan.bloodsucker_sunlight.amDay && total_damage <= 10)
 			Check_End_Torpor()
-	/// You're not in a Coffin, but are in Torpor. Check if you are supposed to end torpor
-	Check_End_Torpor()
+	/// You're not in a Coffin, but are in Torpor. Check if it's not Daytime, & you have less than 10 Brute (NOT Burn) to end Torpor.
+	else if(!clan.bloodsucker_sunlight.amDay && total_brute <= 10 && HAS_TRAIT(owner.current, TRAIT_NODEATH))
+		Check_End_Torpor()
 
 /datum/antagonist/bloodsucker/proc/Check_Begin_Torpor(SkipChecks = FALSE)
 	/// Are we entering Torpor via Sol/Death? Then entering it isnt optional!
@@ -392,7 +392,7 @@
 	if(!clan.bloodsucker_sunlight.amDay && total_damage >= 10 && !HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		Torpor_Begin()
 
-/datum/antagonist/bloodsucker/proc/Check_End_Torpor(SkipChecks = FALSE)
+/datum/antagonist/bloodsucker/proc/Check_End_Torpor()
 	/// You're not in Torpor? (Slept in a Locker for example), then you don't need to leave it.
 	if(!HAS_TRAIT(owner.current, TRAIT_NODEATH))
 		return

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -245,7 +245,7 @@
 // EXPLANATION
 /datum/objective/bloodsucker/heartthief/update_explanation_text()
 	. = ..()
-	explanation_text = "Steal and keep [target_amount] organic heart\s." // TO DO: Limit them to Human Only!
+	explanation_text = "Steal and keep [target_amount] organic heart\s."
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/heartthief/check_completion()

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -363,11 +363,7 @@
 // EXPLANATION
 /datum/objective/bloodsucker/vassal/update_explanation_text()
 	. = ..()
-	explanation_text = "Guarantee the success of your Master's mission! Their objectives are as follows: \n"
-	var/datum/antagonist/vassal/our_vassal = owner.has_antag_datum(/datum/antagonist/vassal)
-	var/datum/antagonist/bloodsucker/our_master = our_vassal.master
-	if(our_master)
-		explanation_text += our_master.objectives.Join("\n")
+	explanation_text = "Guarantee the success of your Master's mission!"
 
 
 // WIN CONDITIONS?

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -57,7 +57,7 @@
 /datum/objective/bloodsucker/protege
 	name = "vassalization"
 
-	var/list/roles = list(
+	var/list/heads = list(
 		"Captain",
 		"Head of Personnel",
 		"Head of Security",
@@ -66,17 +66,17 @@
 		"Chief Medical Officer",
 		"Quartermaster",
 	)
-	var/list/departs = list(
-		"Captain",
-		"Head of Security",
-		"Head of Personnel",
-		"Research Director",
-		"Chief Engineer",
-		"Chief Medical Officer",
+	// Captain doesn't go here because captain is head of the command department, and command has its own objective
+	var/list/heads_w_depart_index = list(
+		"Security" = "Head of Security",
+		"Service or Cargo" = "Head of Personnel",
+		"Science" = "Research Director",
+		"Engineering" = "Chief Engineer",
+		"Medical" = "Chief Medical Officer",
 	)
 
 
-	var/target_role	// Equals "HEAD" when it's not a department role.
+	var/target_role	// The reference role to determine whether or not a job is in a department. Usually the head. Equals "HEAD" if the target department is Command
 	var/department_string
 
 // GENERATE!
@@ -85,33 +85,20 @@
 	switch(rand(0,2))
 		if(0)
 			target_role = "HEAD"
+			target_amount = 1 // Head objectives get one target
 		else
-			target_role = pick(departs)
-	// Now, did we land on Head? We only get one target, then
-	if(target_role == "HEAD")
-		target_amount = 1
-	else
-		// Otherwise, we get 2-3 targets & pick a random Command member, their department is our target.
-		switch(target_role)
-			if("Head of Security")
-				department_string = "Security"
-			if("Head of Personnel")
-				department_string = "Cargo"
-			if("Research Director")
-				department_string = "Science"
-			if("Chief Engineer")
-				department_string = "Engineering"
-			if("Chief Medical Officer")
-				department_string = "Medical"
-		target_amount = rand(2,3)
+			target_role = pick(heads_w_depart_index)
+			department_string = heads_w_depart_index.Find(target_role) // The department is the index!
+			target_amount = rand(2, 3) // Non-head objectives get multiple
 	..()
 
 // EXPLANATION
 /datum/objective/bloodsucker/protege/update_explanation_text()
+	. = ..()
 	if(target_role == "HEAD")
-		explanation_text = "Guarantee a Vassal ends up as a Department Head or in a Leadership role via the Persuasion Rack."
+		explanation_text = "Guarantee a Vassal ends up as a Department Head or in a Leadership role, or convert an existing Head via the Persuasion Rack."
 	else
-		explanation_text = "Have [target_amount] Vassal[target_amount==1?"":"s"] in the [department_string] department via the Persuasion Rack."
+		explanation_text = "Have [target_amount] Vassal\s in the [department_string] department via the Persuasion Rack."
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/protege/check_completion()
@@ -123,7 +110,7 @@
 	// Get list of all jobs that are qualified (for HEAD, this is already done)
 	var/list/valid_jobs
 	if(target_role == "HEAD")
-		valid_jobs = roles
+		valid_jobs = heads
 	else
 		valid_jobs = list()
 		var/list/alljobs = subtypesof(/datum/job) // This is just a list of TYPES, not the actual variables!
@@ -137,7 +124,6 @@
 
 	// Check Vassals, and see if they match
 	var/objcount = 0
-	var/list/counted_roles = list() // So you can't have more than one Captain count.
 	for(var/datum/antagonist/vassal/V in antagdatum.vassals)
 		if(!V || !V.owner)	// Must exist somewhere, and as a vassal.
 			continue
@@ -145,18 +131,18 @@
 		var/thisRole = "none"
 
 		// Mind Assigned
-		if((V.owner.assigned_role in valid_jobs) && !(V.owner.assigned_role in counted_roles))
+		if(V.owner.assigned_role in valid_jobs)
 			//to_chat(owner, "<span class='userdanger'>PROTEGE OBJECTIVE: (MIND ROLE)</span>")
 			thisRole = V.owner.assigned_role
 		// Mob Assigned
-		else if((V.owner.current.job in valid_jobs) && !(V.owner.current.job in counted_roles))
+		else if(V.owner.current.job in valid_jobs)
 			//to_chat(owner, "<span class='userdanger'>PROTEGE OBJECTIVE: (MOB JOB)</span>")
 			thisRole = V.owner.current.job
 		// PDA Assigned
 		else if(V.owner.current && ishuman(V.owner.current))
 			var/mob/living/carbon/human/H = V.owner.current
 			var/obj/item/card/id/I = H.wear_id ? H.wear_id.GetID() : null
-			if(I && (I.assignment in valid_jobs) && !(I.assignment in counted_roles))
+			if(I && (I.assignment in valid_jobs) && (I.registered_name == V.name))
 				//to_chat(owner, "<span class='userdanger'>PROTEGE OBJECTIVE: (GET ID)</span>")
 				thisRole = I.assignment
 
@@ -166,8 +152,6 @@
 
 		// SUCCESS!
 		objcount++
-		if(target_role == "HEAD")
-			counted_roles += thisRole // Add to list so we don't count it again (but only if it's a Head)
 
 	return objcount >= target_amount
 	/* 			NOTE!!!!!!!!!!!
@@ -261,7 +245,7 @@
 // EXPLANATION
 /datum/objective/bloodsucker/heartthief/update_explanation_text()
 	. = ..()
-	explanation_text = "Steal and keep [target_amount] heart[target_amount == 1 ? "" : "s"]." // TO DO: Limit them to Human Only!
+	explanation_text = "Steal and keep [target_amount] organic heart\s." // TO DO: Limit them to Human Only!
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/heartthief/check_completion()
@@ -271,7 +255,9 @@
 	var/itemcount = FALSE
 	for(var/obj/I in all_items)
 		if(istype(I, /obj/item/organ/heart/))
-			itemcount++
+			var/obj/item/organ/heart/heart_item = I
+			if(!(heart_item.organ_flags & ORGAN_SYNTHETIC)) // No robo-hearts allowed
+				itemcount++
 			if(itemcount >= target_amount)
 				return TRUE
 
@@ -293,7 +279,7 @@
 
 // EXPLANATION
 /datum/objective/bloodsucker/vassalhim/update_explanation_text()
-	..()
+	. = ..()
 	if(target?.current)
 		explanation_text = "Ensure [target.name], the [!target_role_type ? target.assigned_role : target.special_role], is Vassalized via the Persuasion Rack."
 	else
@@ -376,9 +362,15 @@
 
 // EXPLANATION
 /datum/objective/bloodsucker/vassal/update_explanation_text()
-	explanation_text = "Guarantee the success of your Master's mission!"
+	. = ..()
+	explanation_text = "Guarantee the success of your Master's mission! Their objectives are as follows: \n"
+	var/datum/antagonist/vassal/our_vassal = owner.has_antag_datum(/datum/antagonist/vassal)
+	var/datum/antagonist/bloodsucker/our_master = our_vassal.master
+	if(our_master)
+		explanation_text += our_master.objectives.Join("\n")
+
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/vassal/check_completion()
 	var/datum/antagonist/vassal/antag_datum = owner.has_antag_datum(/datum/antagonist/vassal)
-	return antag_datum.master && antag_datum.master.owner && antag_datum.master.owner.current && antag_datum.master.owner.current.stat != DEAD
+	return antag_datum.master?.owner?.current?.stat != DEAD

--- a/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/bloodsucker/bloodsucker_objectives.dm
@@ -96,7 +96,7 @@
 /datum/objective/bloodsucker/protege/update_explanation_text()
 	. = ..()
 	if(target_role == "HEAD")
-		explanation_text = "Guarantee a Vassal ends up as a Department Head or in a Leadership role, or convert an existing Head via the Persuasion Rack."
+		explanation_text = "Guarantee a Department Head or someone in a Leadership role is your loyal servant by the end of the day via the Persuasion Rack."
 	else
 		explanation_text = "Have [target_amount] Vassal\s in the [department_string] department via the Persuasion Rack."
 

--- a/fulp_modules/main_features/bloodsuckers/code/powers/_powers.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/_powers.dm
@@ -44,9 +44,9 @@
 	///Do we need to be standing and ready?
 	var/must_be_capacitated = FALSE
 	///Brawn can be used when incapacitated/laying if it's because you're being immobilized. NOTE: If must_be_capacitated is FALSE, this is irrelevant.
-	var/can_be_immobilized = FALSE
+	var/can_use_w_immobilize = FALSE
 	///Can I use this while staked?
-	var/can_be_staked = FALSE
+	var/can_use_w_stake = FALSE
 	///Feed, Masquerade, and One-Shot powers don't improve their cooldown.
 	var/cooldown_static = FALSE
 	/// This goes to Vassals or Hunters, but NOT bloodsuckers. - Replaced with vassal_can_buy kept here because Monsterhunters??
@@ -118,7 +118,7 @@
 			to_chat(owner, "<span class='warning'>Not while you're in Torpor.</span>")
 		return FALSE
 	// Stake?
-	if(!can_be_staked && owner.AmStaked())
+	if(!can_use_w_stake && owner.AmStaked())
 		if(display_error)
 			to_chat(owner, "<span class='warning'>You have a stake in your chest! Your powers are useless.</span>")
 		return FALSE
@@ -134,7 +134,7 @@
 	// Incapacitated?
 	if(must_be_capacitated)
 		var/mob/living/L = owner
-		if (!can_be_immobilized && (!(L.mobility_flags & MOBILITY_STAND) || L.incapacitated(ignore_restraints=TRUE,ignore_grab=TRUE)))
+		if (!can_use_w_immobilize && (!(L.mobility_flags & MOBILITY_STAND) || L.incapacitated(ignore_restraints=TRUE,ignore_grab=TRUE)))
 			if(display_error)
 				to_chat(owner, "<span class='warning'>Not while you're incapacitated!</span>")
 			return FALSE

--- a/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/brawn.dm
@@ -7,7 +7,7 @@
 	target_range = 1
 	power_activates_immediately = TRUE
 	must_be_capacitated = TRUE
-	can_be_immobilized = TRUE
+	can_use_w_immobilize = TRUE
 	bloodsucker_can_buy = TRUE
 	// Level Up
 	var/upgrade_canLocker = FALSE
@@ -15,7 +15,7 @@
 
 /datum/action/bloodsucker/targeted/brawn/CheckCanUse(display_error)
 	. = ..()
-	if(!..(display_error)) // DEFAULT CHECKS
+	if(!.) // DEFAULT CHECKS
 		return FALSE
 	var/usedPower = TRUE // Break Out of Restraints! (And then cancel)
 	if(CheckBreakRestraints())

--- a/fulp_modules/main_features/bloodsuckers/code/powers/feed.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/feed.dm
@@ -7,7 +7,7 @@
 	cooldown = 30
 	amToggle = TRUE
 	bloodsucker_can_buy = FALSE
-	can_be_staked = TRUE
+	can_use_w_stake = TRUE
 	cooldown_static = TRUE
 	can_use_in_frenzy = TRUE
 

--- a/fulp_modules/main_features/bloodsuckers/code/powers/gohome.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/gohome.dm
@@ -15,7 +15,7 @@
 	bloodsucker_can_buy = FALSE
 	can_use_in_torpor = TRUE
 	must_be_capacitated = TRUE
-	can_be_immobilized = TRUE
+	can_use_w_immobilize = TRUE
 	must_be_concious = FALSE
 
 /datum/action/bloodsucker/gohome/CheckCanUse(display_error)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/masquerade.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/masquerade.dm
@@ -56,7 +56,7 @@
 	REMOVE_TRAIT(user, TRAIT_GENELESS, SPECIES_TRAIT)
 
 	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
-	E.flash_protect += 1
+	E.flash_protect = initial(E.flash_protect)
 
 	// WE ARE ALIVE! //
 	var/obj/item/organ/heart/vampheart/H = user.getorganslot(ORGAN_SLOT_HEART)
@@ -103,7 +103,7 @@
 	H.Stop()
 	var/obj/item/organ/eyes/E = user.getorganslot(ORGAN_SLOT_EYES)
 	if(E)
-		E.flash_protect -= 1
+		E.flash_protect = max(initial(E.flash_protect) - 1, FLASH_PROTECTION_SENSITIVE)
 
 	/// Remove all diseases
 	for(var/thing in user.diseases)

--- a/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
+++ b/fulp_modules/main_features/bloodsuckers/code/powers/trespass.dm
@@ -9,7 +9,7 @@
 	can_use_in_frenzy = TRUE
 	bloodsucker_can_buy = TRUE
 	must_be_capacitated = FALSE
-	can_be_immobilized = TRUE
+	can_use_w_immobilize = TRUE
 	var/turf/target_turf // We need to decide where we're going based on where we clicked. It's not actually the tile we clicked.
 
 /datum/action/bloodsucker/targeted/trespass/CheckCanUse(display_error)


### PR DESCRIPTION
## About The Pull Request

These changes are COMPLETELY UNTESTED for the time being-- I only made sure it would build. I'll do the testing personally once you verify that these fit the bloodsucker vision. 

TODO:
Get rid of the last remaining Sleep() procs by handling passive blood drain in bloodsucker_life
Attempt to figure out what's wrong with HUDs
Move unclaiming outside of process, make it occur when a BS claims a new coffin (If this is how you would want it to work)
See if I can reduce code duplication on HandleFeeding
Review powers code, since it's the last block of code I haven't skimmed over

## Why It's Good For The Game

Fewer bugs good

## Changelog
:cl:
code: Added defines for frenzy thresholds and the bloodsucker volume for max regen
code: Added a frenzy threshold variable to bloodsuckers, which is modified by clan gain
code: Removed code from on_removal that is handled in the parent proc
code: Added a DisableAllPowers proc to prevent code duplication
code: Modified word usage in bloodsucker_coffin for clarity
code: Modified amInCoffinWhileTorpor varname for clarity
code: Costmult is now modified by being in a coffin, since the comments says that's supposed to be the case
code: Added a sanity check to HandleHealing so it doesn't perform unnecessary equations while mult is 0
code: Removed a comment from HandleHealing that says a mult of 0 is used to enter torpor, since checks to enter torpor do not use this
code: Added a default costmult in check_limbs (Just in case)
code: Fixed comments in the checking torpor code, removed unnecessary checks handled in the procs
code: Standardized calling the parent proc to . = ..() in update_explanation_text for objectives, for clarity and consistency
code: Condensed the vassal check_completion() proc (I have NO IDEA if this works)
code: Changed wording of some of the variables for bloodsucker's powers for clarity
code: Removed the counted_roles check because it was only used for heads, whose objectives only require 1 vassal anyways
code: Added \s where it can be used
fix: Only counts organic hearts for the heart thief objective
fix: Fixed brawn's CheckCanUse proc calling its parent twice
fix: Changed the bloodsucker objective list to be a referential list, removed "Captain" since it wasn't given a department string previously
fix: check_limbs now uses limbregencost, which is now negative, instead of giving blood volume upon use
fix: When a bloodsucker's eyes are given their vulnerability, adds a sanity check to make sure they do not go below flash protection sensitive, and modifies their value based on the initial value instead of decrementing
fix: Fixed the jitter condition in HandleStarving
fix: Added an additional regen tier so that being above 700 blood doesn't give you no additional regen
fix: Modified the lost blood volume equation so that it accounts for mult and costmult properly. If the intention is for it to not account for mult at all, then it can be removed from the equation
qol: Slightly modified monsterhunter flavor
qol: Gives the bloodsucker's vassals their master's missions
qol: When masquerade would stop you from healing, it just disables itself instead of warning the user
spellcheck: Corrected 'Malakavian' in bloodsucker_flaws
/:cl: